### PR TITLE
feature: add Brave, Firefox, & Firefox Focus iOS app URL schemes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -297,7 +297,7 @@ toc::[]
 
 |Brave
 |`brave://open-url?url=`
-|urlencode the URL to be opened
+|Urlencode the URL to be opened
 
 |Brushstroke 
 |`brushstroke://`


### PR DESCRIPTION
Add entries for iPhone & iPad browser apps:

- Brave: `brave://open-url?url=`
- Firefox:  `firefox://open-url?url=` _Append `&private=true` to open in a private tab_
- Firefox Focus: `firefox-focus://open-url?url=` _Append `&private=true` to open in a private tab_

Notes for each one indicate that the appended URL value should be urlencoded.