### PR TITLE
Add Apple Music URL schemes in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,11 +27,11 @@ toc::[]
 
 |Apple Music
 |`music://` or `musics://` or `audio-player-event://`
-|
+|Any `music.apple.com` link works by switching out `https` with `music`/`musics` (e.g. <https://music.apple.com/playlist/pl.567c541f63414e798be5cf214e155557> -> `music://music.apple.com/playlist/pl.567c541f63414e798be5cf214e155557`). `playlist/pl.<playlist-id>`, `song/<song-id>` (credits), `album/<album-id>[?i=<song-id>]` (album, optionally highlighting a specific song on the album), `station/ra.<station-id>`, `profile/<user-id>`, and `music-video/<video-id>` all are valid to occur after `music.apple.com/`. `song-id`, `video-id` and `album-id` are numeric values, and `playlist-id` and `station-id` are alphanumeric and may include hyphens.
 
 |Apple Music Classical
 |`classical://`
-|
+|Likely works the same as Apple Music url schemes (see above). Untested.
 
 |Apple News 
 |`applenews://` or `applenewss://`

--- a/README.adoc
+++ b/README.adoc
@@ -27,11 +27,11 @@ toc::[]
 
 |Apple Music
 |`music://` or `musics://` or `audio-player-event://`
-|Any `music.apple.com` link works by switching out `https` with `music`/`musics` (e.g. <https://music.apple.com/playlist/pl.567c541f63414e798be5cf214e155557> -> `music://music.apple.com/playlist/pl.567c541f63414e798be5cf214e155557`). `playlist/pl.<playlist-id>`, `song/<song-id>` (credits), `album/<album-id>[?i=<song-id>]` (album, optionally highlighting a specific song on the album), `station/ra.<station-id>`, `profile/<user-id>`, and `music-video/<video-id>` all are valid to occur after `music.apple.com/`. `song-id`, `video-id` and `album-id` are numeric values, and `playlist-id` and `station-id` are alphanumeric and may include hyphens.
+|Any `music.apple.com` (or `classical.music.apple.com`) link works by switching out `https` with `music`/`musics` (e.g. <https://music.apple.com/playlist/pl.567c541f63414e798be5cf214e155557> -> `music://music.apple.com/playlist/pl.567c541f63414e798be5cf214e155557`). `playlist/pl.<playlist-id>`, `song/<song-id>` (credits), `album/<album-id>[?i=<song-id>]` (album, optionally highlighting a specific song on the album), `station/ra.<station-id>`, `profile/<user-id>`, and `music-video/<video-id>` all are valid to occur after `music.apple.com/`. `song-id`, `video-id` and `album-id` are numeric values, and `playlist-id` and `station-id` are alphanumeric and may include hyphens.
 
 |Apple Music Classical
 |`classical://`
-|Likely works the same as Apple Music url schemes (see above). Untested.
+|
 
 |Apple News 
 |`applenews://` or `applenewss://`


### PR DESCRIPTION
Updated the README to clarify how valid links for Apple Music are created.